### PR TITLE
Add build script for Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 current-stream-guru
 web-ts/
 reports/
+dist/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 
     "listener":  "deno run -A scripts/dict-listener.ts",
     "audit":     "deno run -A scripts/audit.ts",
+    "build": "node scripts/build.js",
 
     "test": "echo \"no tests yet\" && exit 0"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,10 @@
+const { rmSync, cpSync } = require('fs');
+const { join } = require('path');
+
+const outDir = join(__dirname, '..', 'dist');
+const srcDir = join(__dirname, '..', 'web');
+
+rmSync(outDir, { recursive: true, force: true });
+cpSync(srcDir, outDir, { recursive: true });
+
+console.log(`Copied ${srcDir} to ${outDir}`);


### PR DESCRIPTION
## Summary
- add Node build script to copy `web` directory into `dist`
- wire up `npm run build` to execute the script
- ignore generated `dist` folder

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890bce10d4c8327b6cf410488344bfe