### PR TITLE
fix: output static site to public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ node_modules/
 current-stream-guru
 web-ts/
 reports/
-dist/
+public/

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,11 @@
 const { rmSync, cpSync } = require('fs');
 const { join } = require('path');
 
-const outDir = join(__dirname, '..', 'dist');
+// Vercel expects static assets to live in a directory named "public" after the
+// build step. Previously we copied the `web` folder to `dist`, which caused the
+// build to fail because Vercel couldn't find the `public` directory. Copy the
+// source assets to `public` instead so deployment succeeds.
+const outDir = join(__dirname, '..', 'public');
 const srcDir = join(__dirname, '..', 'web');
 
 rmSync(outDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- copy web assets into `public` instead of `dist` so Vercel finds the expected output dir
- ignore generated `public` directory

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c6ce5f908327af327df95af7871b